### PR TITLE
chore: Bump version to 0.3.7 and fix missing platform directories in …

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -6,9 +6,16 @@ build/
 **/.gradle/
 **/.dart_tool/
 
-# Platform folders - not needed for pure Flutter packages
-ios/
-android/
+# Platform-specific build artifacts (keep source dirs for plugin)
+ios/build/
+ios/Pods/
+ios/.symlinks/
+ios/Runner/
+ios/Runner.xcworkspace/
+ios/Flutter/
+android/build/
+android/.gradle/
+android/local.properties
 
 # IDE
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## Version 0.3.7 - May 22, 2026
+
+### Bug Fixes
+
+#### Critical: iOS plugin missing from published package
+* Fixed `.pubignore` that incorrectly excluded `ios/` and `android/` directories — users on 0.3.5 saw `Module 'smart_liveliness_detection' not found` at build time because the podspec and Swift source files were absent from the pub.dev tarball
+* Replaced broad platform-folder exclusions with targeted exclusions for build artifacts only (`ios/build/`, `ios/Pods/`, `ios/.symlinks/`, `android/build/`, etc.) so `ios/Classes/`, `ios/smart_liveliness_detection.podspec`, and `android/src/` are now correctly published
+
 ## Version 0.3.6 - April 25, 2026
 * Minor bug fixes and stability improvements
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add this package to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  smart_liveliness_detection: ^0.3.5
+  smart_liveliness_detection: ^0.3.6
 ```
 
 Then run:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smart_liveliness_detection
 description: This package helps you verify that a real person is present in front of the camera, not a photo, video, or mask.
-version: 0.3.6
+version: 0.3.7
 homepage: https://github.com/demola234/smart_liveliness_detection
 
 environment:


### PR DESCRIPTION
- Fix `.pubignore` by replacing broad `ios/` and `android/` exclusions with specific build artifact exclusions to ensure source files are included in the published package
- Update version to `0.3.7` in `pubspec.yaml` and `CHANGELOG.md`
- Update `README.md` dependency example to `^0.3.6`

Closes: #28 #30 #31 #29 